### PR TITLE
Bug Fix Lambda None type error

### DIFF
--- a/tools/etc/make_lba_import.py
+++ b/tools/etc/make_lba_import.py
@@ -11,16 +11,11 @@ if __name__ == '__main__':
         data = read_csv(
             sys.argv[1],
             skiprows=7,
-            sep=r"\s*\|\s*",
-            engine='python',
-            names=['Type', 'Name', 'Length', 'LBA', 'Timecode', 'Bytes', 'Source'],
+            sep=r'\s+',
             usecols=['Type', 'Name', 'LBA', 'Length'],
             converters={
-                'Name': lambda n: n.strip().removesuffix(';1').replace('.', '_'),
-                'LBA': lambda l: l.strip(),
-                'Length': lambda l: l.strip(),
+                'Name': lambda n: n.removesuffix(';1').replace('.', '_') if n is not None else '',
             },
-            skip_blank_lines=True,
         ).query('Type == "File" or Type == "XA"')
 
         data['define'] = '#define'


### PR DESCRIPTION
# LBA Lambda None Type
This one broke the build. So rolling it back

## Issue
Using pipes '|' instead of whitespace ' ' for separators results in None type in the lambda 

## Fix
Roll back to earlier version (possible that a files was missing from the previous commit)
