### PR TITLE
Decomp func_800C05B4

### DIFF
--- a/src/BATTLE/BATTLE.PRG/573B8.c
+++ b/src/BATTLE/BATTLE.PRG/573B8.c
@@ -71,7 +71,13 @@ INCLUDE_ASM(
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/573B8", func_800C031C);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/573B8", func_800C05B4);
+void func_800C05B4(void)
+{
+    if (D_800EB9B8 != NULL) {
+        vs_main_freeHeap(D_800EB9B8);
+        D_800EB9B8 = NULL;
+    }
+}
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/573B8", func_800C05EC);
 


### PR DESCRIPTION
## Summary
- Decompiles `func_800C05B4` in `src/BATTLE/BATTLE.PRG/573B8.c`
- Replaces the `INCLUDE_ASM` stub with matching C
- Frees `D_800EB9B8` when allocated, and resets it to `NULL`

## Verification
- `GIT_MASTER=1 git diff --check`
- `docker run --rm -v "$PWD":/work -w /work rood-reverse-dev:latest make CPP=mipsel-linux-gnu-cpp commit-check`
- Result: `All files match`

## Disclosure
worked with AI to get this done. I reviewed the changes, ran the verification steps, and take responsibility for the contribution 🫡