### PR TITLE
Decomp func_8009FD38

### DIFF
--- a/src/BATTLE/BATTLE.PRG/30D14.c
+++ b/src/BATTLE/BATTLE.PRG/30D14.c
@@ -247,7 +247,13 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/30D14", func_8009FC20);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/30D14", func_8009FC60);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/30D14", func_8009FD38);
+void func_8009FD38(u_char* arg0)
+{
+    *(short*)(arg0 + 0x17FA) = 30;
+    if (*(u_short*)(arg0 + 0x63C) >= 0x81) {
+        *(short*)(arg0 + 0x17FA) = 20;
+    }
+}
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/30D14", func_8009FD5C);
 

--- a/src/BATTLE/BATTLE.PRG/30D14.c
+++ b/src/BATTLE/BATTLE.PRG/30D14.c
@@ -247,11 +247,18 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/30D14", func_8009FC20);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/30D14", func_8009FC60);
 
-void func_8009FD38(u_char* arg0)
+typedef struct {
+    char unk0[0x63C];
+    u_short unk63C;
+    char unk63E[0x11BC];
+    short unk17FA;
+} func_8009FD38_t;
+
+void func_8009FD38(func_8009FD38_t* arg0)
 {
-    *(short*)(arg0 + 0x17FA) = 30;
-    if (*(u_short*)(arg0 + 0x63C) >= 0x81) {
-        *(short*)(arg0 + 0x17FA) = 20;
+    arg0->unk17FA = 30;
+    if (arg0->unk63C > 128) {
+        arg0->unk17FA = 20;
     }
 }
 


### PR DESCRIPTION
## Summary
- Decompiles `func_8009FD38` in `BATTLE.PRG/30D14.c` (a small leaf that writes a `short` field to 30, then to 20 when another `u_short` field is >= 0x81).
- Matches byte-for-byte; verified with a full `make clean && make -j` → "All files match".

## Test plan
- [x] `make -j` reports all files match
- [x] `make clean && make -j` reports all files match