### PR TITLE
Decomp libcd: CdStatus, CdMode, CdLastCom (+ Makefile commit-check fix)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,16 +46,14 @@ all: check
 check: $$(TARGETS)
 
 commit-check: format
-	$(MAKE) remake
-	$(MAKE) objdiff
+	$(MAKE) --no-print-directory remake
+	$(MAKE) --no-print-directory objdiff
 
 clean:
 	$(RM) $(RMFLAGS) $(BUILD) nonmatchings
 
 remake: clean
-	$(MAKE)
-
-commit-check remake: MAKEFLAGS += --no-print-directory
+	$(MAKE) --no-print-directory
 
 include $(INCMAKEFILES)
 

--- a/src/SLUS_010.40/libcd/SYS.c
+++ b/src/SLUS_010.40/libcd/SYS.c
@@ -1,10 +1,20 @@
 #include "common.h"
 
-INCLUDE_ASM("build/src/SLUS_010.40/nonmatchings/libcd/SYS", CdStatus);
+typedef void (*CdlCB)(unsigned char, unsigned char*);
 
-INCLUDE_ASM("build/src/SLUS_010.40/nonmatchings/libcd/SYS", CdMode);
+extern unsigned char D_80032208;
+extern unsigned char D_80032214[];
+extern unsigned char D_80032218;
+extern unsigned char D_80032219;
+extern int D_80032204;
+extern CdlCB D_800321FC;
+extern CdlCB D_80032200;
 
-INCLUDE_ASM("build/src/SLUS_010.40/nonmatchings/libcd/SYS", CdLastCom);
+int CdStatus(void) { return D_80032208; }
+
+int CdMode(void) { return D_80032218; }
+
+int CdLastCom(void) { return D_80032219; }
 
 INCLUDE_ASM("build/src/SLUS_010.40/nonmatchings/libcd/SYS", CdLastPos);
 


### PR DESCRIPTION
## Summary

Two small commits:

1. **libcd: match CdStatus, CdMode, CdLastCom** — ported from sotn-decomp's `src/main/psxsdk/libcd/sys.c` (same compiler, 2.7.2-psx). All three are simple state-getters around psyq's static `_cd_status`/`_cd_mode`/`_cd_lastcom`.
2. **Makefile: pass `--no-print-directory` explicitly to sub-makes** — GNU Make 4.4+ (which is what `flake.nix` ships) parses long flags appended to target-specific `MAKEFLAGS` as targets in the sub-make, breaking `make commit-check`. Passing the flag directly to each `$(MAKE)` invocation works on all make versions.

## Test plan
- [x] `nix develop -c make commit-check` runs end-to-end (was previously failing on `--no-print-directory`)
- [x] `nix develop -c bash -lc 'make format && git diff --exit-code'` clean
- [x] All target files match after a clean `make -j`
- [x] No edits outside `src/SLUS_010.40/libcd/` and `Makefile`