### PR TITLE
Decomp func_800C110C

### DIFF
--- a/src/BATTLE/BATTLE.PRG/58578.c
+++ b/src/BATTLE/BATTLE.PRG/58578.c
@@ -124,7 +124,62 @@ void func_800C0FA8(func_800C0FA8_t* arg0, func_800C0FA8_t2* arg1, MATRIX* arg2)
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/58578", func_800C1034);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/58578", func_800C110C);
+int func_800C110C(func_800C1564_t* arg0, u_short* arg1, int arg2)
+{
+    func_800C0FA8_t2 work;
+    MATRIX matrix;
+    int sum;
+    int term;
+    int i;
+
+    func_800C0FA8((func_800C0FA8_t*)arg0, &work, &matrix);
+
+    {
+        char* ptr;
+        char* base;
+        int offset;
+
+        i = 0;
+        ptr = (char*)&work;
+        base = ptr;
+        offset = 0x10;
+        while (i < 3) {
+            *(short*)ptr = *arg1++ - *(u_short*)(base + offset);
+            offset += 2;
+            i++;
+            ptr += 2;
+        }
+    }
+
+    sum = 0;
+    ApplyMatrixSV(&matrix, &work.unk0, (SVECTOR*)((char*)&work + 8));
+    if (arg2 != 0) {
+        ((SVECTOR*)&work.unk8)->vy -= arg0->unk4.unk1 << 4;
+    }
+
+    {
+        if (!((u_short)(-((SVECTOR*)&work.unk8)->vy) > (arg0->unk4.unk1 << 5))) {
+            char* base;
+            int offset2;
+            int offset;
+
+            i = 0;
+            base = (char*)&work;
+            offset2 = 0x18;
+            offset = 8;
+            while (i < 3) {
+                term = (*(short*)(base + offset) * *(short*)(base + offset2)) >> 12;
+                sum += term * term;
+                offset2 += 4;
+                offset += 4;
+                i += 2;
+            }
+
+            sum = (u_int)(sum >> 16) < 1;
+        }
+    }
+    return sum;
+}
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/58578", func_800C123C);
 


### PR DESCRIPTION
## Summary
- Decompiles `func_800C110C` in `src/BATTLE/BATTLE.PRG/58578.c`.
- Keeps the change focused to the source replacement for the existing `INCLUDE_ASM` fallback.

## Verification
- `docker run --rm --platform linux/amd64 -v "$PWD:/work" -w /work rood-reverse-dev:latest make CPP=mipsel-linux-gnu-cpp check`
- `docker run --rm --platform linux/amd64 -v "$PWD:/work" -w /work rood-reverse-dev:latest make CPP=mipsel-linux-gnu-cpp commit-check`
- `GIT_MASTER=1 git diff --check`

AI assistance was used to prepare and verify this change.