### PR TITLE
Decomp func_800AF6E8

### DIFF
--- a/src/BATTLE/BATTLE.PRG/44F14.c
+++ b/src/BATTLE/BATTLE.PRG/44F14.c
@@ -3,6 +3,9 @@
 #include "3A1A0.h"
 #include "../../SLUS_010.40/main.h"
 
+void func_800AF844(D_800F4538_unkC54*, D_800F4538_unkC54*, int);
+void func_800B147C(D_800F4538_unkC54*, D_800F4538_unkC54*, int, int, int);
+
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/44F14", func_800AD714);
 
 void func_800AE46C(void) { }
@@ -40,7 +43,48 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/44F14", func_800AEEC4);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/44F14", func_800AEF94);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/44F14", func_800AF6E8);
+void func_800AF6E8(void* arg0)
+{
+    D_800F4538_t* actor = (D_800F4538_t*)arg0;
+    int v5b2;
+    int next;
+    int fa2;
+    int fa3;
+
+    func_800AFA28(actor, &actor->unkC54, 0);
+    if (actor->unk5CC != 0) {
+        if (actor->unk5CC == 1) {
+            func_800AF844(&actor->unk704, &actor->unkC54, actor->unk0);
+        }
+        v5b2 = actor->unk5B2;
+        if (v5b2 != 1) {
+            next = actor->unk5CC + 0xFF;
+            actor->unk5CC = v5b2 + next;
+            if ((u_int)((v5b2 + next) & 0xFF) >= actor->unk5CD) {
+                actor->unk5CC = 0;
+                actor->unk5CD = 0;
+                goto tail;
+            }
+        }
+        func_800B147C(
+            &actor->unk704, &actor->unkC54, actor->unk0, actor->unk5CC, actor->unk5CD);
+        fa2 = (actor->unk704.unk548 & 0xFFFEFFFF)
+            | ((((u_short*)&actor->unkC54.unk548)[1] & 1) << 16);
+        actor->unk704.unk548 = fa2;
+        fa3 = (fa2 & 0xFFFDFFFF) | (actor->unkC54.unk548 & 0x20000);
+        actor->unk704.unk548 = fa3;
+        func_800B002C(actor, 0, fa2, fa3);
+        actor->unk5CC++;
+        if (actor->unk5CC >= actor->unk5CD) {
+            actor->unk5CC = 0;
+            actor->unk5CD = 0;
+        }
+    } else {
+    tail:
+        vs_main_memcpy(&actor->unk704, &actor->unkC54, sizeof(actor->unk704));
+        func_800B002C(actor, 0);
+    }
+}
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/44F14", func_800AF844);
 

--- a/src/BATTLE/BATTLE.PRG/44F14.h
+++ b/src/BATTLE/BATTLE.PRG/44F14.h
@@ -6,5 +6,5 @@ void func_800AEAE8(void*);
 void func_800AECA0(void*);
 void func_800AF6E8(void*);
 void func_800AFA28(D_800F4538_t*, D_800F4538_unkC54*, int);
-void func_800B002C(void*, int);
+void func_800B002C();
 void func_800B217C(void*, void*);


### PR DESCRIPTION
Matches `func_800AF6E8` in `BATTLE.PRG/44F14.c`.

Advances an actor's animation between its two `D_800F4538_unkC54` buffers
(`unk704` working copy, `unkC54` source). After a `func_800AFA28` call it
branches on the frame counter `unk5CC`:

- Counter non-zero: on the first frame (`== 1`) it initializes via
  `func_800AF844`; advances the counter by `unk5B2 - 1` (wrapping to 0 at
  `unk5CD`); interpolates with `func_800B147C`; copies flag bits 0x10000 /
  0x20000 from `unkC54.unk548` into `unk704.unk548`; calls `func_800B002C`;
  then increments the counter (again wrapping at `unk5CD`).
- Counter zero: copies the source buffer over the working copy
  (`vs_main_memcpy(&unk704, &unkC54, sizeof unk704)`) and calls
  `func_800B002C`. The wrap-to-zero case also branches into this shared tail.

Notes:
- `44F14.c`: added local prototypes for `func_800AF844` and `func_800B147C`.
- `44F14.h`: widened the `func_800B002C` decl to unspecified args
  (`void func_800B002C();`) — it's called with two args by its other caller
  and four here.
- No struct changes. The `unkC4C`/`unk119C`/`unk119E` flag accesses map to the
  existing nested fields `unk704.unk548`, `unkC54.unk548`, and the high half
  of `unkC54.unk548`.
- Left `progress.json` out of this PR since it regenerates on your end (it kept
  conflicting on the previous ones).

objdiff: 100% (byte-perfect). Full `BATTLE.PRG` builds and the tree verifies
"All files match".
