### PR TITLE
Decomp func_800D5198

### DIFF
--- a/src/BATTLE/BATTLE.PRG/5BF94.c
+++ b/src/BATTLE/BATTLE.PRG/5BF94.c
@@ -3587,7 +3587,12 @@ int func_800D5150(D_800F53B8_t* arg0 __attribute__((unused)))
 
 u_char func_800D5170(D_800F53B8_t* arg0) { return arg0->unkC[arg0->unkA++]; }
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D5198);
+u_short func_800D5198(D_800F53B8_t* arg0)
+{
+    u_char lo = func_800D5170(arg0);
+    u_char hi = func_800D5170(arg0);
+    return lo | (hi << 8);
+}
 
 int func_800D51D8(D_800F53B8_t* arg0)
 {


### PR DESCRIPTION
Decompiles `func_800D5198` in `BATTLE.PRG/5BF94.c` to a byte-perfect match (`make check`: all files match).

It reads two bytes from the command stream via `func_800D5170` (the byte fetcher) and combines them into a little-endian `u_short`: `lo | (hi << 8)`. Used throughout the stream parser to read 16-bit operands.