### PR TITLE
Decomp func_800D46DC

### DIFF
--- a/src/BATTLE/BATTLE.PRG/5BF94.c
+++ b/src/BATTLE/BATTLE.PRG/5BF94.c
@@ -3384,7 +3384,14 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D2A38);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D2ADC);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D46DC);
+void func_800D46DC(int arg0, D_800F53B8_t* arg1)
+{
+    if (arg0) {
+        arg1->unkA = func_800D5198(arg1);
+    } else {
+        arg1->unkA += 2;
+    }
+}
 
 int func_800D4720(D_800F53B8_t* arg0)
 {


### PR DESCRIPTION
Decompiles `func_800D46DC` in `BATTLE.PRG/5BF94.c` to a byte-perfect match (`make check`: all files match).

It's the conditional-branch opcode in the battle command-stream VM. Given a condition and the parser state, it either seeks the stream read position (`unkA`) to the 16-bit target read via `func_800D5198` (branch taken), or skips the 2-byte operand (`unkA += 2`, branch not taken). Called from 5 condition-check sites in the interpreter.