### PR TITLE
Decomp func_800D2970, func_800D5564

### DIFF
--- a/src/BATTLE/BATTLE.PRG/5BF94.c
+++ b/src/BATTLE/BATTLE.PRG/5BF94.c
@@ -3357,7 +3357,12 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D2888);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D2904);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D2970);
+void func_800D2970(VECTOR* arg0, VECTOR* arg1, VECTOR* arg2)
+{
+    arg2->vx = arg0->vx + arg1->vx;
+    arg2->vy = arg0->vy + arg1->vy;
+    arg2->vz = arg0->vz + arg1->vz;
+}
 
 void _addVecToSvec(VECTOR* arg0, SVECTOR* arg1, VECTOR* arg2)
 {
@@ -3614,7 +3619,11 @@ void* func_800D5550(u_short* arg0, int arg1)
     return (char*)arg0 + v[2];
 }
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D5564);
+void* func_800D5564(u_short* arg0, int arg1, int arg2)
+{
+    u_short* v = (u_short*)func_800D5550(arg0, arg1) + arg2 * 2;
+    return (char*)arg0 + v[3];
+}
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D55A4);
 


### PR DESCRIPTION
Two small functions in `5BF94.c`:

- `func_800D2970`: component-wise `VECTOR` add (`out = a + b`).
- `func_800D5564`: relative-pointer table accessor, mirroring the existing `func_800D5550` idiom; called by `func_800D55A4`.

Both byte-exact; `make check` reports all files match.