### PR TITLE
Decomp func_800AA984 (40564): set actor turn target/speed

### DIFF
--- a/src/BATTLE/BATTLE.PRG/3A1A0.h
+++ b/src/BATTLE/BATTLE.PRG/3A1A0.h
@@ -154,7 +154,9 @@ typedef struct {
     int unk38;
     u_short unk3C;
     u_short unk3E;
-    int unk40[6];
+    u_short unk40;
+    u_short unk42;
+    int unk44[5];
     D_800F4538_unk58_2 unk58;
     u_char unk5C;
     u_char unk5D;

--- a/src/BATTLE/BATTLE.PRG/40564.c
+++ b/src/BATTLE/BATTLE.PRG/40564.c
@@ -115,7 +115,44 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/40564", func_800AA850);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/40564", func_800AA8D0);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/40564", func_800AA984);
+void func_800AA984(int arg0, short arg1, int arg2)
+{
+    D_800F4538_t* a;
+    int m;
+    int speed;
+    short sum;
+
+    a = D_800F4538[arg0];
+    if (a != NULL) {
+        m = arg1;
+        a->unk0.unk3E = m;
+        a->unk0.unk3C = 0;
+        a->unk0.unk40 = 0;
+        if (arg2 == 0) {
+            a->unk0.unk18 = 0;
+        recenter:
+            sum = (u_short)a->unk0.unk26 + a->unk0.unk3E;
+            a->unk0.unk26 = sum;
+            a->unk0.unk26 = sum % 4096;
+            return;
+        }
+        if (arg2 == -1) {
+            if (m < 0) {
+                m = -m;
+            }
+            speed = m * a->unk5C0;
+            a->unk0.unk18 = speed / 4096;
+            if (speed & 0xFFF) {
+                a->unk0.unk18 = (speed / 4096) + 1;
+            }
+            if (a->unk0.unk18 == 0) {
+                goto recenter;
+            }
+            return;
+        }
+        a->unk0.unk18 = arg2;
+    }
+}
 
 void func_800AAA68(void) { func_800AAA88(); }
 


### PR DESCRIPTION
Matches func_800AA984 in BATTLE.PRG (40564.c, 2.7.2-cdk).

Sets an actor's turn: stores the target angle (unk3E), then per `arg2`:
- `0`: instant turn (speed 0) and apply the rotation now;
- `-1`: derive turn speed = ceil(|angle| * unk5C0 / 4096), applying immediately if it rounds to 0;
- otherwise: use `arg2` as the explicit speed.

The immediate-apply path wraps the current angle (unk26) into [0, 4096), matching the existing idiom in func_800A97EC.

Also narrows `D_800F4538_unk0.unk40` from `int[6]` to `u_short` (+ size-preserving filler) to match the 16-bit store at 0x40; that array was unused elsewhere. `make check` → all files match.