### PR TITLE
Decomp func_800D6388, func_800D63D0 (5BF94): forward actor sub-record by mode

### DIFF
--- a/src/BATTLE/BATTLE.PRG/146C.c
+++ b/src/BATTLE/BATTLE.PRG/146C.c
@@ -2067,7 +2067,7 @@ int func_8006C84C(int arg0)
     return 1;
 }
 
-void func_8006CA20(int arg0)
+void func_8006CA20(int arg0, func_8006CE70_t* arg1)
 {
     int temp_v1;
     D_800F19CC_t2* temp_s0;

--- a/src/BATTLE/BATTLE.PRG/146C.h
+++ b/src/BATTLE/BATTLE.PRG/146C.h
@@ -935,6 +935,8 @@ typedef struct {
 
 void func_80069C6C(int);
 void func_8006CDB8(int);
+void func_8006CA20(int, func_8006CE70_t*);
+void func_8006CB04(int, func_8006CE70_t*);
 void func_80069FC4(int, int);
 void vs_battle_copyInventoryBladeStats(vs_battle_uiEquipment*, vs_battle_inventoryBlade*);
 void vs_battle_copyInventoryGripStats(vs_battle_uiEquipment*, vs_battle_inventoryGrip*);

--- a/src/BATTLE/BATTLE.PRG/5BF94.c
+++ b/src/BATTLE/BATTLE.PRG/5BF94.c
@@ -58,7 +58,10 @@ typedef struct {
     u_short unk2;
     short unk4;
     short unk6;
-    int unk8;
+    union {
+        int s32;
+        short s16[2];
+    } unk8;
 } D_800F53B8_t3_2;
 
 typedef struct {
@@ -3692,9 +3695,25 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D6298);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D6310);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D6388);
+void func_800D6388(D_800F53B8_t* arg0)
+{
+    if (arg0->unkD1C.unk18.unk0 == 4) {
+        func_8006CB04((u_char)arg0->unkD1C.unk18.unk4, NULL);
+    } else {
+        func_8006CB04(
+            arg0->unkD1C.unk18.unk8.s16[1], (func_8006CE70_t*)&arg0->unkD1C.unk18.unk4);
+    }
+}
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D63D0);
+void func_800D63D0(D_800F53B8_t* arg0)
+{
+    if (arg0->unkD1C.unk0.unk0 == 4) {
+        func_8006CA20((u_char)arg0->unkD1C.unk0.unk4, NULL);
+    } else {
+        func_8006CA20(
+            arg0->unkD1C.unk0.unk8.s16[1], (func_8006CE70_t*)&arg0->unkD1C.unk0.unk4);
+    }
+}
 
 void func_800D6418(D_800F53B8_t* arg0)
 {


### PR DESCRIPTION
Two sibling handlers that read a `D_800F53B8_t3_2` sub-record's mode discriminator (`unk0`): when it is 4, pass the record's `u8` id and `NULL` to the helper; otherwise pass the signed 16-bit field at +0xA together with a pointer to the record. They are the two-branch counterparts of the already-matched single-branch siblings `func_800D6574` / `func_800D66CC`.

Refines `D_800F53B8_t3_2.unk8` from a bare `int` into `union { int s32; short s16[2]; }` so the +0xA half-word is addressable while keeping a 4-byte member — this preserves the struct's word-copy alignment (a plain `short` split silently downgraded the whole-struct copies to half-words and shifted every later function).

`func_8006CA20` gains its second (record-pointer) argument; `func_8006CB04` is prototyped to match. Both are its only callers.

`make check` → all files match.