### PR TITLE
Decomp func_800D118C

### DIFF
--- a/src/BATTLE/BATTLE.PRG/5BF94.c
+++ b/src/BATTLE/BATTLE.PRG/5BF94.c
@@ -3270,7 +3270,17 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D0D08);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D1104);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D118C);
+u_char func_800D118C(int arg0, int arg1)
+{
+    func_800D0B30_t1* temp = (func_800D0B30_t1*)D_800F569C->unk8C;
+    int idx;
+
+    if (arg0 != 0 && temp->unk0 >= arg0) {
+        idx = arg0 - 1;
+        return ((u_char*)D_800F569C->unkC[idx])[arg1 % ((u_char*)temp)[(long)(idx + 4)]];
+    }
+    return 0;
+}
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/5BF94", func_800D11F4);
 


### PR DESCRIPTION
Decompiles `func_800D118C` in `BATTLE.PRG/5BF94.c`.

A leaf accessor reached via `D_800F569C->unk8C`: it bounds-checks the 1-based index against the entry count, then returns `unkC[idx-1][arg1 % bytes[idx-1]]` — indexing the per-entry divisor byte array and the per-entry pointer array.

Byte-matching; `make check` passes (all files match). Source-only change (no header or struct changes needed — existing types reused via casts).