### PR TITLE
Decomp func_800A190C

### DIFF
--- a/src/BATTLE/BATTLE.PRG/38C1C.c
+++ b/src/BATTLE/BATTLE.PRG/38C1C.c
@@ -156,7 +156,59 @@ int func_800A1720(int arg0, int arg1, int* arg2, int* arg3)
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/38C1C", func_800A17BC);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/38C1C", func_800A190C);
+int func_800A190C(int arg0, int arg1, SVECTOR* arg2, int arg3)
+{
+    D_800F4538_t* var_a2;
+    int var_v0;
+
+    if (arg1 == 0xFB) {
+        var_a2 = D_800F4538[arg0];
+
+        if (var_a2 == NULL) {
+            var_a2 = (D_800F4538_t*)D_800F45E0[arg0];
+            if (var_a2 == NULL) {
+                return -1;
+            }
+
+            *arg2 = var_a2->unk0.position;
+            arg2->vy -= 0xC0;
+        } else {
+            *arg2 = var_a2->unk0.position;
+            arg2->vy -= var_a2->unk646;
+        }
+
+        return 0;
+    }
+
+    if (arg1 == 0xFD) {
+        *arg2 = D_800F4538[arg0]->unk0.position;
+        return 0;
+    }
+
+    if ((arg1 & 0xF0) == 0x40) {
+        var_v0 = arg1;
+    } else if (arg1 == 0xFA) {
+        var_a2 = D_800F4538[arg0];
+        *arg2 = var_a2->unk0.position;
+        var_v0 = var_a2->unk65A * var_a2->unk183C / ONE;
+        arg2->vy += var_v0;
+        return 0;
+    } else {
+        var_v0 = func_800A152C(arg0, arg1, 0);
+
+        if (var_v0 < 0) {
+            return var_v0;
+        }
+    }
+
+    var_v0 = func_800A1C10(arg0, var_v0, (u_short*)arg2, arg3);
+
+    if (var_v0 < 0) {
+        return var_v0;
+    }
+
+    return 0;
+}
 
 int func_800A1AF8(int arg0, int arg1, u_short* arg2, int arg3)
 {

--- a/src/BATTLE/BATTLE.PRG/3A1A0.h
+++ b/src/BATTLE/BATTLE.PRG/3A1A0.h
@@ -283,7 +283,7 @@ typedef struct {
     u_short unk654;
     u_short menuCameraDistance;
     u_short unk658;
-    u_short unk65A;
+    short unk65A;
     int unk65C;
     int unk660;
     u_int btSeqLbas[12];


### PR DESCRIPTION
`func_800A190C` writes an actor position into the caller's buffer. `arg1` selects which one.

- `0xFB` root position, less `unk646`, or less `0xC0` on the `D_800F45E0` fallback
- `0xFD` root position, no offset and no null test
- `0xFA` root position, plus `unk65A * unk183C / 0x1000`
- top nibble 4 selects a weapon bone, which `func_800A1C10` decodes itself
- anything else resolves to a bone index through `func_800A152C`

22 callers, all still assembly.

`D_800F4538_t.unk65A` becomes `short`. The multiply reads it with `lh`. No other code reads the field, and the size and the alignment hold.

`make remake -j8` matches. clang-format 18.1.3 reports no diff.
