### PR TITLE
Decomp func_800A3310

### DIFF
--- a/src/BATTLE/BATTLE.PRG/3A1A0.c
+++ b/src/BATTLE/BATTLE.PRG/3A1A0.c
@@ -80,7 +80,20 @@ void func_800A3054(D_800F4538_t* arg0, func_800A3054_t* arg1)
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/3A1A0", func_800A30A0);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/3A1A0", func_800A3310);
+int func_800A3310(int arg0, SVECTOR* arg1)
+{
+    int i;
+
+    for (i = 2; i < arg0; ++i) {
+        D_800F4538_t* temp_a2 = D_800F4538[i];
+        if (temp_a2 != NULL && temp_a2->unk0.unkA_5
+            && *(int*)&temp_a2->unk0.position == *(int*)arg1
+            && temp_a2->unk0.position.vz == arg1->vz) {
+            return i;
+        }
+    }
+    return 0;
+}
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/3A1A0", func_800A3394);
 


### PR DESCRIPTION
Returns either the index of the actor at the given position, or 0. Had to use gcc 2.7.2-970404 + maspsx with -O2 -G0 -Wall -funsigned-char -Wa,--aspsx-version=2.77 to get 100% on decomp.me