### PR TITLE
Decomp func_800D7FFC

### DIFF
--- a/src/BATTLE/BATTLE.PRG/6E644.c
+++ b/src/BATTLE/BATTLE.PRG/6E644.c
@@ -1,5 +1,7 @@
 #include "common.h"
 
+extern int D_800F5638;
+
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D6E44);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7814);
@@ -54,7 +56,7 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7FC8);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7FE4);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7FFC);
+void func_800D7FFC(int arg0) { D_800F5638 = arg0; }
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D8008);
 


### PR DESCRIPTION
First function from the new 6E644.c. Sets D_800F5638, declared extern int.