### PR TITLE
Decomp func_800D8054

### DIFF
--- a/src/BATTLE/BATTLE.PRG/6E644.c
+++ b/src/BATTLE/BATTLE.PRG/6E644.c
@@ -62,7 +62,9 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D8038);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D8044);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D8054);
+extern int D_800F5690;
+
+void func_800D8054(int arg0) { D_800F5690 = arg0; }
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D8060);
 


### PR DESCRIPTION
Sets D_800F5690, declared extern int above the function.