### PR TITLE
Decomp func_800D8200

### DIFF
--- a/src/BATTLE/BATTLE.PRG/6E644.c
+++ b/src/BATTLE/BATTLE.PRG/6E644.c
@@ -66,7 +66,7 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D8054);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D8060);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D8200);
+int func_800D8200(void) { return 0x14C08; }
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D820C);
 


### PR DESCRIPTION
Returns the constant 0x14C08, used as a CD file id by func_800CE9B0.