### PR TITLE
Decomp func_800D7FB4

### DIFF
--- a/src/BATTLE/BATTLE.PRG/6E644.c
+++ b/src/BATTLE/BATTLE.PRG/6E644.c
@@ -48,7 +48,13 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7CFC);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7EF4);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7FB4);
+extern u_short D_800F5688[2];
+
+void func_800D7FB4(int arg0, int arg1)
+{
+    D_800F5688[0] = arg0;
+    D_800F5688[1] = arg1;
+}
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7FC8);
 


### PR DESCRIPTION
Sets the two shorts at D_800F5688 (file id offset and size, read by func_800D7BF8). Declared as u_short[2].