### PR TITLE
Decomp func_800D7FE4

### DIFF
--- a/src/BATTLE/BATTLE.PRG/6E644.c
+++ b/src/BATTLE/BATTLE.PRG/6E644.c
@@ -52,7 +52,13 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7FB4);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7FC8);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7FE4);
+struct func_800D4910_t;
+extern int (*D_800F56A8[])(struct func_800D4910_t*, int, int);
+
+void func_800D7FE4(int (*arg0)(struct func_800D4910_t*, int, int), int arg1)
+{
+    D_800F56A8[arg1] = arg0;
+}
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7FFC);
 


### PR DESCRIPTION
Stores a callback into D_800F56A8[arg1]. Same array type as the extern in 5BF94.c, with a forward declaration of func_800D4910_t.