### PR TITLE
Decomp func_800D7FC8

### DIFF
--- a/src/BATTLE/BATTLE.PRG/6E644.c
+++ b/src/BATTLE/BATTLE.PRG/6E644.c
@@ -50,7 +50,15 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7EF4);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7FB4);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7FC8);
+extern u_short D_800F5694[2];
+extern int D_800F56A4;
+
+void func_800D7FC8(int arg0, int arg1, int arg2)
+{
+    D_800F5694[0] = arg0;
+    D_800F5694[1] = arg1;
+    D_800F56A4 = arg2;
+}
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800D7FE4);
 


### PR DESCRIPTION
Sets the D_800F5694 pair (same shape as D_800F5688, read by func_800D7EF4) and D_800F56A4.