### PR TITLE
Decomp func_800E5A74

### DIFF
--- a/src/BATTLE/BATTLE.PRG/6E644.c
+++ b/src/BATTLE/BATTLE.PRG/6E644.c
@@ -364,7 +364,15 @@ INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800E5710);
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800E5998);
 
-INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800E5A74);
+typedef struct {
+    int unk0;
+    u_short unk4;
+} func_800E5A74_t;
+
+void func_800E5A74(int* arg0, func_800E5A74_t* arg1)
+{
+    *arg0 = ((arg1->unk4 & 0xFFE) << 20) | (*arg0 & 0x1FFFFF);
+}
 
 INCLUDE_ASM("build/src/BATTLE/BATTLE.PRG/nonmatchings/6E644", func_800E5A9C);
 


### PR DESCRIPTION
Packs bits 1-11 of arg1->unk4 into the top 11 bits of *arg0. New struct func_800E5A74_t with only unk4 named.